### PR TITLE
Add time argument to get the running time of each test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ clean:
 	rm -rf cromwell-executions
 	rm -rf cromwell-workflow-logs
 	rm -rf wdl-out-*
-	find -name "_LAST" -delete
+	find tests -name "_version_1.0*.wdl" -delete
+	find tests -name "_version_1.1*.wdl" -delete
+	find tests -name "_version_draft-2*.wdl" -delete
 
 cromwell:
 	mkdir -p build

--- a/conformance.yaml
+++ b/conformance.yaml
@@ -665,7 +665,7 @@
     wdl: read_string_as_command.wdl
     json: read_string.json
   outputs:
-    readStringWorkflow.read_string.the_output:
+    readStringWorkflow.the_output:
       type: File
       value: {md5sum: '91d69f7c47b6e7d5e4d81fab67f7f304'}
 - description: |

--- a/tests/read_string_as_command/read_string_as_command.wdl
+++ b/tests/read_string_as_command/read_string_as_command.wdl
@@ -5,6 +5,10 @@ workflow readStringWorkflow {
   }
 
   call read_string {input: in_file=in_file}
+
+  output {
+    File the_output = read_string.the_output
+  }
 }
 
 task read_string {


### PR DESCRIPTION
This resolves #16 

`--time` will grab the real, user, and system time of each test while running each test sequentially. It might be better to just record the real or user time, but it seems like there is a significant different between real time and user time for toil-wdl-runner's, and including the 3 is not too complicated.

This also has a stray fix for a WDL test that had an incorrect output, and fixes a race condition issue.