### PR TITLE
Update syntax error in conformance

### DIFF
--- a/conformance.yaml
+++ b/conformance.yaml
@@ -963,6 +963,9 @@
     wf.result4:
       type: Boolean
       value: True
+    wf.result5:
+      type: Boolean
+      value: True
 - description: | # toil-wdl-runner currently fails this
     Test that passing a file generated with write_lines() into another task succeeds
   versions: ["draft-2", "1.0", "1.1"]

--- a/tests/read_string_as_command/read_string_as_command.wdl
+++ b/tests/read_string_as_command/read_string_as_command.wdl
@@ -5,7 +5,6 @@ workflow readStringWorkflow {
   }
 
   call read_string {input: in_file=in_file}
-
   output {
     File the_output = read_string.the_output
   }


### PR DESCRIPTION
The current sibling files test on main is missing an expected output in conformance.yaml, so it's currently failing when it shouldn't.