### PR TITLE
Re-indent Python Code Blocks in Integration tests

### DIFF
--- a/integration/gatk/encode/encode_mapping_workflow.wdl
+++ b/integration/gatk/encode/encode_mapping_workflow.wdl
@@ -39,7 +39,7 @@ task mapping {
     }
 
     runtime {
-        docker: 'quay.io/encode-dcc/mapping:v1.0'
+        docker: 'quay.io/stxue/encode-dcc-mapping:latest'
         cpu: 2
         memory: '4.1 GB'
         disks: 'local-disk 5 HDD'
@@ -75,7 +75,7 @@ task post_processing {
     }
 
     runtime {
-        docker: 'quay.io/encode-dcc/post_mapping:v1.0'
+        docker: 'quay.io/stxue/encode-dcc-post-mapping:latest'
         cpu: 2
         memory: '4.1 GB'
         disks: 'local-disk 5 HDD'
@@ -108,7 +108,7 @@ task filter_qc {
     }
 
     runtime {
-        docker: 'quay.io/encode-dcc/filter:v1.0'
+        docker: 'quay.io/stxue/encode-dcc-filter'
         cpu: 2
         memory: '4.1 GB'
         disks: 'local-disk 5 HDD'
@@ -138,7 +138,7 @@ task xcor {
     }
 
     runtime {
-        docker: 'quay.io/encode-dcc/xcor:v1.0'
+        docker: 'quay.io/stxue/encode-dcc-xcor'
         cpu: 2
         memory: '4.1 GB'
         disks: 'local-disk 5 HDD'
@@ -197,105 +197,105 @@ task validate_and_gather_the_output {
         cp ~{compare_against_files[4]} ./ref
 
         python <<CODE
-import os
-def compare_runs(output_dir, ref_dir):
-    """
-    Takes two directories and compares all of the files between those two
-    directories, asserting that they match.
+        import os
+        def compare_runs(output_dir, ref_dir):
+            """
+            Takes two directories and compares all of the files between those two
+            directories, asserting that they match.
 
-    - Ignores outputs.txt, which contains a list of the outputs in the folder.
-    - Compares line by line, unless the file is a .vcf file.
-    - Ignores potentially date-stamped comments (lines starting with '#').
-    - Ignores quality scores in .vcf files and only checks that they found
-      the same variants.  This is due to assumed small observed rounding
-      differences between systems.
+            - Ignores outputs.txt, which contains a list of the outputs in the folder.
+            - Compares line by line, unless the file is a .vcf file.
+            - Ignores potentially date-stamped comments (lines starting with '#').
+            - Ignores quality scores in .vcf files and only checks that they found
+            the same variants.  This is due to assumed small observed rounding
+            differences between systems.
 
-    :param ref_dir: The first directory to compare (with output_dir).
-    :param output_dir: The second directory to compare (with ref_dir).
-    """
-    reference_output_files = os.listdir(ref_dir)
-    for file in reference_output_files:
-        if file not in ('outputs.txt', '__pycache__'):
-            test_output_files = os.listdir(output_dir)
-            filepath = os.path.join(ref_dir, file)
-            with open(filepath) as default_file:
+            :param ref_dir: The first directory to compare (with output_dir).
+            :param output_dir: The second directory to compare (with ref_dir).
+            """
+            reference_output_files = os.listdir(ref_dir)
+            for file in reference_output_files:
+                if file not in ('outputs.txt', '__pycache__'):
+                    test_output_files = os.listdir(output_dir)
+                    filepath = os.path.join(ref_dir, file)
+                    with open(filepath) as default_file:
+                        good_data = []
+                        for line in default_file:
+                            if not line.startswith('#'):
+                                good_data.append(line)
+                        for test_file in test_output_files:
+                            if file == test_file:
+                                test_filepath = os.path.join(output_dir, file)
+                                if file.endswith(".vcf"):
+                                    compare_vcf_files(filepath1=filepath,
+                                                    filepath2=test_filepath)
+                                else:
+                                    with open(test_filepath) as test_file:
+                                        test_data = []
+                                        for line in test_file:
+                                            if not line.startswith('#'):
+                                                test_data.append(line)
+                                    assert good_data == test_data, "File does not match: %r" % file
+
+
+        def compare_vcf_files(filepath1, filepath2):
+            """
+            Asserts that two .vcf files contain the same variant findings.
+
+            - Ignores potentially date-stamped comments (lines starting with '#').
+            - Ignores quality scores in .vcf files and only checks that they found
+            the same variants.  This is due to assumed small observed rounding
+            differences between systems.
+
+            VCF File Column Contents:
+            1: #CHROM
+            2: POS
+            3: ID
+            4: REF
+            5: ALT
+            6: QUAL
+            7: FILTER
+            8: INFO
+
+            :param filepath1: First .vcf file to compare.
+            :param filepath2: Second .vcf file to compare.
+            """
+            with open(filepath1) as default_file:
                 good_data = []
                 for line in default_file:
+                    line = line.strip()
                     if not line.startswith('#'):
-                        good_data.append(line)
-                for test_file in test_output_files:
-                    if file == test_file:
-                        test_filepath = os.path.join(output_dir, file)
-                        if file.endswith(".vcf"):
-                            compare_vcf_files(filepath1=filepath,
-                                              filepath2=test_filepath)
-                        else:
-                            with open(test_filepath) as test_file:
-                                test_data = []
-                                for line in test_file:
-                                    if not line.startswith('#'):
-                                        test_data.append(line)
-                            assert good_data == test_data, "File does not match: %r" % file
+                        good_data.append(line.split('\t'))
 
+            with open(filepath2) as test_file:
+                test_data = []
+                for line in test_file:
+                    line = line.strip()
+                    if not line.startswith('#'):
+                        test_data.append(line.split('\t'))
 
-def compare_vcf_files(filepath1, filepath2):
-    """
-    Asserts that two .vcf files contain the same variant findings.
+            for i in range(len(test_data)):
+                if test_data[i] != good_data[i]:
+                    for j in range(len(test_data[i])):
+                        # Only compare chromosome, position, ID, reference, and alts.
+                        # Quality score may vary (<1%) between systems because of
+                        # (assumed) rounding differences.  Same for the "info" sect.
+                        if j < 5:
+                            if j == 4:
+                                if test_data[i][j].startswith('*,'):
+                                    test_data[i][j] = test_data[i][j][2:]
+                                if good_data[i][j].startswith('*,'):
+                                    good_data[i][j] = good_data[i][j][2:]
+                            assert test_data[i][j] == good_data[i][j], f"\nInconsistent VCFs: {filepath1} != {filepath2}\n" \
+                                                                    f" - {test_data[i][j]} != {good_data[i][j]}\n" \
+                                                                    f" - Line: {i} Column: {j}"
 
-    - Ignores potentially date-stamped comments (lines starting with '#').
-    - Ignores quality scores in .vcf files and only checks that they found
-      the same variants.  This is due to assumed small observed rounding
-      differences between systems.
-
-    VCF File Column Contents:
-    1: #CHROM
-    2: POS
-    3: ID
-    4: REF
-    5: ALT
-    6: QUAL
-    7: FILTER
-    8: INFO
-
-    :param filepath1: First .vcf file to compare.
-    :param filepath2: Second .vcf file to compare.
-    """
-    with open(filepath1) as default_file:
-        good_data = []
-        for line in default_file:
-            line = line.strip()
-            if not line.startswith('#'):
-                good_data.append(line.split('\t'))
-
-    with open(filepath2) as test_file:
-        test_data = []
-        for line in test_file:
-            line = line.strip()
-            if not line.startswith('#'):
-                test_data.append(line.split('\t'))
-
-    for i in range(len(test_data)):
-        if test_data[i] != good_data[i]:
-            for j in range(len(test_data[i])):
-                # Only compare chromosome, position, ID, reference, and alts.
-                # Quality score may vary (<1%) between systems because of
-                # (assumed) rounding differences.  Same for the "info" sect.
-                if j < 5:
-                    if j == 4:
-                        if test_data[i][j].startswith('*,'):
-                            test_data[i][j] = test_data[i][j][2:]
-                        if good_data[i][j].startswith('*,'):
-                            good_data[i][j] = good_data[i][j][2:]
-                    assert test_data[i][j] == good_data[i][j], f"\nInconsistent VCFs: {filepath1} != {filepath2}\n" \
-                                                               f" - {test_data[i][j]} != {good_data[i][j]}\n" \
-                                                               f" - Line: {i} Column: {j}"
-
-try:
-    compare_runs(os.path.join(os.getcwd(), "output"), os.path.join(os.getcwd(), "ref"))
-    print("success")
-except AssertionError as e:
-    print("fail", e)
-CODE
+        try:
+            compare_runs(os.path.join(os.getcwd(), "output"), os.path.join(os.getcwd(), "ref"))
+            print("success")
+        except AssertionError as e:
+            print("fail", e)
+        CODE
     >>>
 
     output {

--- a/integration/gatk/tut01/helloHaplotypeCaller.wdl
+++ b/integration/gatk/tut01/helloHaplotypeCaller.wdl
@@ -56,7 +56,7 @@ task haplotypeCaller {
   }
 
   runtime {
-    docker: 'ibmjava:latest'
+    docker: 'quay.io/stxue/ibmjava:8'
   }
 }
 
@@ -75,105 +75,105 @@ task validate_and_gather_the_output {
         cp ~{compare_against_file} ./ref
 
         python <<CODE
-import os
-def compare_runs(output_dir, ref_dir):
-    """
-    Takes two directories and compares all of the files between those two
-    directories, asserting that they match.
+        import os
+        def compare_runs(output_dir, ref_dir):
+            """
+            Takes two directories and compares all of the files between those two
+            directories, asserting that they match.
 
-    - Ignores outputs.txt, which contains a list of the outputs in the folder.
-    - Compares line by line, unless the file is a .vcf file.
-    - Ignores potentially date-stamped comments (lines starting with '#').
-    - Ignores quality scores in .vcf files and only checks that they found
-      the same variants.  This is due to assumed small observed rounding
-      differences between systems.
+            - Ignores outputs.txt, which contains a list of the outputs in the folder.
+            - Compares line by line, unless the file is a .vcf file.
+            - Ignores potentially date-stamped comments (lines starting with '#').
+            - Ignores quality scores in .vcf files and only checks that they found
+              the same variants.  This is due to assumed small observed rounding
+              differences between systems.
 
-    :param ref_dir: The first directory to compare (with output_dir).
-    :param output_dir: The second directory to compare (with ref_dir).
-    """
-    reference_output_files = os.listdir(ref_dir)
-    for file in reference_output_files:
-        if file not in ('outputs.txt', '__pycache__'):
-            test_output_files = os.listdir(output_dir)
-            filepath = os.path.join(ref_dir, file)
-            with open(filepath) as default_file:
+            :param ref_dir: The first directory to compare (with output_dir).
+            :param output_dir: The second directory to compare (with ref_dir).
+            """
+            reference_output_files = os.listdir(ref_dir)
+            for file in reference_output_files:
+                if file not in ('outputs.txt', '__pycache__'):
+                    test_output_files = os.listdir(output_dir)
+                    filepath = os.path.join(ref_dir, file)
+                    with open(filepath) as default_file:
+                        good_data = []
+                        for line in default_file:
+                            if not line.startswith('#'):
+                                good_data.append(line)
+                        for test_file in test_output_files:
+                            if file == test_file:
+                                test_filepath = os.path.join(output_dir, file)
+                                if file.endswith(".vcf"):
+                                    compare_vcf_files(filepath1=filepath,
+                                                      filepath2=test_filepath)
+                                else:
+                                    with open(test_filepath) as test_file:
+                                        test_data = []
+                                        for line in test_file:
+                                            if not line.startswith('#'):
+                                                test_data.append(line)
+                                    assert good_data == test_data, "File does not match: %r" % file
+
+
+        def compare_vcf_files(filepath1, filepath2):
+            """
+            Asserts that two .vcf files contain the same variant findings.
+
+            - Ignores potentially date-stamped comments (lines starting with '#').
+            - Ignores quality scores in .vcf files and only checks that they found
+              the same variants.  This is due to assumed small observed rounding
+              differences between systems.
+
+            VCF File Column Contents:
+            1: #CHROM
+            2: POS
+            3: ID
+            4: REF
+            5: ALT
+            6: QUAL
+            7: FILTER
+            8: INFO
+
+            :param filepath1: First .vcf file to compare.
+            :param filepath2: Second .vcf file to compare.
+            """
+            with open(filepath1) as default_file:
                 good_data = []
                 for line in default_file:
+                    line = line.strip()
                     if not line.startswith('#'):
-                        good_data.append(line)
-                for test_file in test_output_files:
-                    if file == test_file:
-                        test_filepath = os.path.join(output_dir, file)
-                        if file.endswith(".vcf"):
-                            compare_vcf_files(filepath1=filepath,
-                                              filepath2=test_filepath)
-                        else:
-                            with open(test_filepath) as test_file:
-                                test_data = []
-                                for line in test_file:
-                                    if not line.startswith('#'):
-                                        test_data.append(line)
-                            assert good_data == test_data, "File does not match: %r" % file
+                        good_data.append(line.split('\t'))
 
+            with open(filepath2) as test_file:
+                test_data = []
+                for line in test_file:
+                    line = line.strip()
+                    if not line.startswith('#'):
+                        test_data.append(line.split('\t'))
 
-def compare_vcf_files(filepath1, filepath2):
-    """
-    Asserts that two .vcf files contain the same variant findings.
+            for i in range(len(test_data)):
+                if test_data[i] != good_data[i]:
+                    for j in range(len(test_data[i])):
+                        # Only compare chromosome, position, ID, reference, and alts.
+                        # Quality score may vary (<1%) between systems because of
+                        # (assumed) rounding differences.  Same for the "info" sect.
+                        if j < 5:
+                            if j == 4:
+                                if test_data[i][j].startswith('*,'):
+                                    test_data[i][j] = test_data[i][j][2:]
+                                if good_data[i][j].startswith('*,'):
+                                    good_data[i][j] = good_data[i][j][2:]
+                            assert test_data[i][j] == good_data[i][j], f"\nInconsistent VCFs: {filepath1} != {filepath2}\n" \
+                                                                       f" - {test_data[i][j]} != {good_data[i][j]}\n" \
+                                                                       f" - Line: {i} Column: {j}"
 
-    - Ignores potentially date-stamped comments (lines starting with '#').
-    - Ignores quality scores in .vcf files and only checks that they found
-      the same variants.  This is due to assumed small observed rounding
-      differences between systems.
-
-    VCF File Column Contents:
-    1: #CHROM
-    2: POS
-    3: ID
-    4: REF
-    5: ALT
-    6: QUAL
-    7: FILTER
-    8: INFO
-
-    :param filepath1: First .vcf file to compare.
-    :param filepath2: Second .vcf file to compare.
-    """
-    with open(filepath1) as default_file:
-        good_data = []
-        for line in default_file:
-            line = line.strip()
-            if not line.startswith('#'):
-                good_data.append(line.split('\t'))
-
-    with open(filepath2) as test_file:
-        test_data = []
-        for line in test_file:
-            line = line.strip()
-            if not line.startswith('#'):
-                test_data.append(line.split('\t'))
-
-    for i in range(len(test_data)):
-        if test_data[i] != good_data[i]:
-            for j in range(len(test_data[i])):
-                # Only compare chromosome, position, ID, reference, and alts.
-                # Quality score may vary (<1%) between systems because of
-                # (assumed) rounding differences.  Same for the "info" sect.
-                if j < 5:
-                    if j == 4:
-                        if test_data[i][j].startswith('*,'):
-                            test_data[i][j] = test_data[i][j][2:]
-                        if good_data[i][j].startswith('*,'):
-                            good_data[i][j] = good_data[i][j][2:]
-                    assert test_data[i][j] == good_data[i][j], f"\nInconsistent VCFs: {filepath1} != {filepath2}\n" \
-                                                               f" - {test_data[i][j]} != {good_data[i][j]}\n" \
-                                                               f" - Line: {i} Column: {j}"
-
-try:
-    compare_runs(os.path.join(os.getcwd(), "output"), os.path.join(os.getcwd(), "ref"))
-    print("success")
-except AssertionError as e:
-    print("fail", e)
-CODE
+        try:
+            compare_runs(os.path.join(os.getcwd(), "output"), os.path.join(os.getcwd(), "ref"))
+            print("success")
+        except AssertionError as e:
+            print("fail", e)
+        CODE
     >>>
 
     output {

--- a/integration/gatk/tut02/simpleVariantSelection.wdl
+++ b/integration/gatk/tut02/simpleVariantSelection.wdl
@@ -129,105 +129,105 @@ task validate_and_gather_the_output {
         cp ~{compare_against_files[2]} ./ref
 
         python <<CODE
-import os
-def compare_runs(output_dir, ref_dir):
-    """
-    Takes two directories and compares all of the files between those two
-    directories, asserting that they match.
+        import os
+        def compare_runs(output_dir, ref_dir):
+            """
+            Takes two directories and compares all of the files between those two
+            directories, asserting that they match.
 
-    - Ignores outputs.txt, which contains a list of the outputs in the folder.
-    - Compares line by line, unless the file is a .vcf file.
-    - Ignores potentially date-stamped comments (lines starting with '#').
-    - Ignores quality scores in .vcf files and only checks that they found
-      the same variants.  This is due to assumed small observed rounding
-      differences between systems.
+            - Ignores outputs.txt, which contains a list of the outputs in the folder.
+            - Compares line by line, unless the file is a .vcf file.
+            - Ignores potentially date-stamped comments (lines starting with '#').
+            - Ignores quality scores in .vcf files and only checks that they found
+              the same variants.  This is due to assumed small observed rounding
+              differences between systems.
 
-    :param ref_dir: The first directory to compare (with output_dir).
-    :param output_dir: The second directory to compare (with ref_dir).
-    """
-    reference_output_files = os.listdir(ref_dir)
-    for file in reference_output_files:
-        if file not in ('outputs.txt', '__pycache__'):
-            test_output_files = os.listdir(output_dir)
-            filepath = os.path.join(ref_dir, file)
-            with open(filepath) as default_file:
+            :param ref_dir: The first directory to compare (with output_dir).
+            :param output_dir: The second directory to compare (with ref_dir).
+            """
+            reference_output_files = os.listdir(ref_dir)
+            for file in reference_output_files:
+                if file not in ('outputs.txt', '__pycache__'):
+                    test_output_files = os.listdir(output_dir)
+                    filepath = os.path.join(ref_dir, file)
+                    with open(filepath) as default_file:
+                        good_data = []
+                        for line in default_file:
+                            if not line.startswith('#'):
+                                good_data.append(line)
+                        for test_file in test_output_files:
+                            if file == test_file:
+                                test_filepath = os.path.join(output_dir, file)
+                                if file.endswith(".vcf"):
+                                    compare_vcf_files(filepath1=filepath,
+                                                      filepath2=test_filepath)
+                                else:
+                                    with open(test_filepath) as test_file:
+                                        test_data = []
+                                        for line in test_file:
+                                            if not line.startswith('#'):
+                                                test_data.append(line)
+                                    assert good_data == test_data, "File does not match: %r" % file
+
+
+        def compare_vcf_files(filepath1, filepath2):
+            """
+            Asserts that two .vcf files contain the same variant findings.
+
+            - Ignores potentially date-stamped comments (lines starting with '#').
+            - Ignores quality scores in .vcf files and only checks that they found
+              the same variants.  This is due to assumed small observed rounding
+              differences between systems.
+
+            VCF File Column Contents:
+            1: #CHROM
+            2: POS
+            3: ID
+            4: REF
+            5: ALT
+            6: QUAL
+            7: FILTER
+            8: INFO
+
+            :param filepath1: First .vcf file to compare.
+            :param filepath2: Second .vcf file to compare.
+            """
+            with open(filepath1) as default_file:
                 good_data = []
                 for line in default_file:
+                    line = line.strip()
                     if not line.startswith('#'):
-                        good_data.append(line)
-                for test_file in test_output_files:
-                    if file == test_file:
-                        test_filepath = os.path.join(output_dir, file)
-                        if file.endswith(".vcf"):
-                            compare_vcf_files(filepath1=filepath,
-                                              filepath2=test_filepath)
-                        else:
-                            with open(test_filepath) as test_file:
-                                test_data = []
-                                for line in test_file:
-                                    if not line.startswith('#'):
-                                        test_data.append(line)
-                            assert good_data == test_data, "File does not match: %r" % file
+                        good_data.append(line.split('\t'))
 
+            with open(filepath2) as test_file:
+                test_data = []
+                for line in test_file:
+                    line = line.strip()
+                    if not line.startswith('#'):
+                        test_data.append(line.split('\t'))
 
-def compare_vcf_files(filepath1, filepath2):
-    """
-    Asserts that two .vcf files contain the same variant findings.
+            for i in range(len(test_data)):
+                if test_data[i] != good_data[i]:
+                    for j in range(len(test_data[i])):
+                        # Only compare chromosome, position, ID, reference, and alts.
+                        # Quality score may vary (<1%) between systems because of
+                        # (assumed) rounding differences.  Same for the "info" sect.
+                        if j < 5:
+                            if j == 4:
+                                if test_data[i][j].startswith('*,'):
+                                    test_data[i][j] = test_data[i][j][2:]
+                                if good_data[i][j].startswith('*,'):
+                                    good_data[i][j] = good_data[i][j][2:]
+                            assert test_data[i][j] == good_data[i][j], f"\nInconsistent VCFs: {filepath1} != {filepath2}\n" \
+                                                                       f" - {test_data[i][j]} != {good_data[i][j]}\n" \
+                                                                       f" - Line: {i} Column: {j}"
 
-    - Ignores potentially date-stamped comments (lines starting with '#').
-    - Ignores quality scores in .vcf files and only checks that they found
-      the same variants.  This is due to assumed small observed rounding
-      differences between systems.
-
-    VCF File Column Contents:
-    1: #CHROM
-    2: POS
-    3: ID
-    4: REF
-    5: ALT
-    6: QUAL
-    7: FILTER
-    8: INFO
-
-    :param filepath1: First .vcf file to compare.
-    :param filepath2: Second .vcf file to compare.
-    """
-    with open(filepath1) as default_file:
-        good_data = []
-        for line in default_file:
-            line = line.strip()
-            if not line.startswith('#'):
-                good_data.append(line.split('\t'))
-
-    with open(filepath2) as test_file:
-        test_data = []
-        for line in test_file:
-            line = line.strip()
-            if not line.startswith('#'):
-                test_data.append(line.split('\t'))
-
-    for i in range(len(test_data)):
-        if test_data[i] != good_data[i]:
-            for j in range(len(test_data[i])):
-                # Only compare chromosome, position, ID, reference, and alts.
-                # Quality score may vary (<1%) between systems because of
-                # (assumed) rounding differences.  Same for the "info" sect.
-                if j < 5:
-                    if j == 4:
-                        if test_data[i][j].startswith('*,'):
-                            test_data[i][j] = test_data[i][j][2:]
-                        if good_data[i][j].startswith('*,'):
-                            good_data[i][j] = good_data[i][j][2:]
-                    assert test_data[i][j] == good_data[i][j], f"\nInconsistent VCFs: {filepath1} != {filepath2}\n" \
-                                                               f" - {test_data[i][j]} != {good_data[i][j]}\n" \
-                                                               f" - Line: {i} Column: {j}"
-
-try:
-    compare_runs(os.path.join(os.getcwd(), "output"), os.path.join(os.getcwd(), "ref"))
-    print("success")
-except AssertionError as e:
-    print("fail", e)
-CODE
+        try:
+            compare_runs(os.path.join(os.getcwd(), "output"), os.path.join(os.getcwd(), "ref"))
+            print("success")
+        except AssertionError as e:
+            print("fail", e)
+        CODE
     >>>
 
     output {

--- a/integration/gatk/tut03/simpleVariantDiscovery.wdl
+++ b/integration/gatk/tut03/simpleVariantDiscovery.wdl
@@ -249,105 +249,105 @@ task validate_and_gather_the_output {
         cp ~{compare_against_files[5]} ./ref
 
         python <<CODE
-import os
-def compare_runs(output_dir, ref_dir):
-    """
-    Takes two directories and compares all of the files between those two
-    directories, asserting that they match.
+        import os
+        def compare_runs(output_dir, ref_dir):
+            """
+            Takes two directories and compares all of the files between those two
+            directories, asserting that they match.
 
-    - Ignores outputs.txt, which contains a list of the outputs in the folder.
-    - Compares line by line, unless the file is a .vcf file.
-    - Ignores potentially date-stamped comments (lines starting with '#').
-    - Ignores quality scores in .vcf files and only checks that they found
-      the same variants.  This is due to assumed small observed rounding
-      differences between systems.
+            - Ignores outputs.txt, which contains a list of the outputs in the folder.
+            - Compares line by line, unless the file is a .vcf file.
+            - Ignores potentially date-stamped comments (lines starting with '#').
+            - Ignores quality scores in .vcf files and only checks that they found
+              the same variants.  This is due to assumed small observed rounding
+              differences between systems.
 
-    :param ref_dir: The first directory to compare (with output_dir).
-    :param output_dir: The second directory to compare (with ref_dir).
-    """
-    reference_output_files = os.listdir(ref_dir)
-    for file in reference_output_files:
-        if file not in ('outputs.txt', '__pycache__'):
-            test_output_files = os.listdir(output_dir)
-            filepath = os.path.join(ref_dir, file)
-            with open(filepath) as default_file:
+            :param ref_dir: The first directory to compare (with output_dir).
+            :param output_dir: The second directory to compare (with ref_dir).
+            """
+            reference_output_files = os.listdir(ref_dir)
+            for file in reference_output_files:
+                if file not in ('outputs.txt', '__pycache__'):
+                    test_output_files = os.listdir(output_dir)
+                    filepath = os.path.join(ref_dir, file)
+                    with open(filepath) as default_file:
+                        good_data = []
+                        for line in default_file:
+                            if not line.startswith('#'):
+                                good_data.append(line)
+                        for test_file in test_output_files:
+                            if file == test_file:
+                                test_filepath = os.path.join(output_dir, file)
+                                if file.endswith(".vcf"):
+                                    compare_vcf_files(filepath1=filepath,
+                                                      filepath2=test_filepath)
+                                else:
+                                    with open(test_filepath) as test_file:
+                                        test_data = []
+                                        for line in test_file:
+                                            if not line.startswith('#'):
+                                                test_data.append(line)
+                                    assert good_data == test_data, "File does not match: %r" % file
+
+
+        def compare_vcf_files(filepath1, filepath2):
+            """
+            Asserts that two .vcf files contain the same variant findings.
+
+            - Ignores potentially date-stamped comments (lines starting with '#').
+            - Ignores quality scores in .vcf files and only checks that they found
+              the same variants.  This is due to assumed small observed rounding
+              differences between systems.
+
+            VCF File Column Contents:
+            1: #CHROM
+            2: POS
+            3: ID
+            4: REF
+            5: ALT
+            6: QUAL
+            7: FILTER
+            8: INFO
+
+            :param filepath1: First .vcf file to compare.
+            :param filepath2: Second .vcf file to compare.
+            """
+            with open(filepath1) as default_file:
                 good_data = []
                 for line in default_file:
+                    line = line.strip()
                     if not line.startswith('#'):
-                        good_data.append(line)
-                for test_file in test_output_files:
-                    if file == test_file:
-                        test_filepath = os.path.join(output_dir, file)
-                        if file.endswith(".vcf"):
-                            compare_vcf_files(filepath1=filepath,
-                                              filepath2=test_filepath)
-                        else:
-                            with open(test_filepath) as test_file:
-                                test_data = []
-                                for line in test_file:
-                                    if not line.startswith('#'):
-                                        test_data.append(line)
-                            assert good_data == test_data, "File does not match: %r" % file
+                        good_data.append(line.split('\t'))
 
+            with open(filepath2) as test_file:
+                test_data = []
+                for line in test_file:
+                    line = line.strip()
+                    if not line.startswith('#'):
+                        test_data.append(line.split('\t'))
 
-def compare_vcf_files(filepath1, filepath2):
-    """
-    Asserts that two .vcf files contain the same variant findings.
+            for i in range(len(test_data)):
+                if test_data[i] != good_data[i]:
+                    for j in range(len(test_data[i])):
+                        # Only compare chromosome, position, ID, reference, and alts.
+                        # Quality score may vary (<1%) between systems because of
+                        # (assumed) rounding differences.  Same for the "info" sect.
+                        if j < 5:
+                            if j == 4:
+                                if test_data[i][j].startswith('*,'):
+                                    test_data[i][j] = test_data[i][j][2:]
+                                if good_data[i][j].startswith('*,'):
+                                    good_data[i][j] = good_data[i][j][2:]
+                            assert test_data[i][j] == good_data[i][j], f"\nInconsistent VCFs: {filepath1} != {filepath2}\n" \
+                                                                       f" - {test_data[i][j]} != {good_data[i][j]}\n" \
+                                                                       f" - Line: {i} Column: {j}"
 
-    - Ignores potentially date-stamped comments (lines starting with '#').
-    - Ignores quality scores in .vcf files and only checks that they found
-      the same variants.  This is due to assumed small observed rounding
-      differences between systems.
-
-    VCF File Column Contents:
-    1: #CHROM
-    2: POS
-    3: ID
-    4: REF
-    5: ALT
-    6: QUAL
-    7: FILTER
-    8: INFO
-
-    :param filepath1: First .vcf file to compare.
-    :param filepath2: Second .vcf file to compare.
-    """
-    with open(filepath1) as default_file:
-        good_data = []
-        for line in default_file:
-            line = line.strip()
-            if not line.startswith('#'):
-                good_data.append(line.split('\t'))
-
-    with open(filepath2) as test_file:
-        test_data = []
-        for line in test_file:
-            line = line.strip()
-            if not line.startswith('#'):
-                test_data.append(line.split('\t'))
-
-    for i in range(len(test_data)):
-        if test_data[i] != good_data[i]:
-            for j in range(len(test_data[i])):
-                # Only compare chromosome, position, ID, reference, and alts.
-                # Quality score may vary (<1%) between systems because of
-                # (assumed) rounding differences.  Same for the "info" sect.
-                if j < 5:
-                    if j == 4:
-                        if test_data[i][j].startswith('*,'):
-                            test_data[i][j] = test_data[i][j][2:]
-                        if good_data[i][j].startswith('*,'):
-                            good_data[i][j] = good_data[i][j][2:]
-                    assert test_data[i][j] == good_data[i][j], f"\nInconsistent VCFs: {filepath1} != {filepath2}\n" \
-                                                               f" - {test_data[i][j]} != {good_data[i][j]}\n" \
-                                                               f" - Line: {i} Column: {j}"
-
-try:
-    compare_runs(os.path.join(os.getcwd(), "output"), os.path.join(os.getcwd(), "ref"))
-    print("success")
-except AssertionError as e:
-    print("fail", e)
-CODE
+        try:
+            compare_runs(os.path.join(os.getcwd(), "output"), os.path.join(os.getcwd(), "ref"))
+            print("success")
+        except AssertionError as e:
+            print("fail", e)
+        CODE
     >>>
 
     output {

--- a/integration/gatk/tut04/jointCallingGenotypes.wdl
+++ b/integration/gatk/tut04/jointCallingGenotypes.wdl
@@ -122,105 +122,105 @@ task validate_and_gather_the_output {
         cp ~{compare_against_files[0]} ./ref
 
         python <<CODE
-import os
-def compare_runs(output_dir, ref_dir):
-    """
-    Takes two directories and compares all of the files between those two
-    directories, asserting that they match.
+        import os
+        def compare_runs(output_dir, ref_dir):
+            """
+            Takes two directories and compares all of the files between those two
+            directories, asserting that they match.
 
-    - Ignores outputs.txt, which contains a list of the outputs in the folder.
-    - Compares line by line, unless the file is a .vcf file.
-    - Ignores potentially date-stamped comments (lines starting with '#').
-    - Ignores quality scores in .vcf files and only checks that they found
-      the same variants.  This is due to assumed small observed rounding
-      differences between systems.
+            - Ignores outputs.txt, which contains a list of the outputs in the folder.
+            - Compares line by line, unless the file is a .vcf file.
+            - Ignores potentially date-stamped comments (lines starting with '#').
+            - Ignores quality scores in .vcf files and only checks that they found
+              the same variants.  This is due to assumed small observed rounding
+              differences between systems.
 
-    :param ref_dir: The first directory to compare (with output_dir).
-    :param output_dir: The second directory to compare (with ref_dir).
-    """
-    reference_output_files = os.listdir(ref_dir)
-    for file in reference_output_files:
-        if file not in ('outputs.txt', '__pycache__'):
-            test_output_files = os.listdir(output_dir)
-            filepath = os.path.join(ref_dir, file)
-            with open(filepath) as default_file:
+            :param ref_dir: The first directory to compare (with output_dir).
+            :param output_dir: The second directory to compare (with ref_dir).
+            """
+            reference_output_files = os.listdir(ref_dir)
+            for file in reference_output_files:
+                if file not in ('outputs.txt', '__pycache__'):
+                    test_output_files = os.listdir(output_dir)
+                    filepath = os.path.join(ref_dir, file)
+                    with open(filepath) as default_file:
+                        good_data = []
+                        for line in default_file:
+                            if not line.startswith('#'):
+                                good_data.append(line)
+                        for test_file in test_output_files:
+                            if file == test_file:
+                                test_filepath = os.path.join(output_dir, file)
+                                if file.endswith(".vcf"):
+                                    compare_vcf_files(filepath1=filepath,
+                                                      filepath2=test_filepath)
+                                else:
+                                    with open(test_filepath) as test_file:
+                                        test_data = []
+                                        for line in test_file:
+                                            if not line.startswith('#'):
+                                                test_data.append(line)
+                                    assert good_data == test_data, "File does not match: %r" % file
+
+
+        def compare_vcf_files(filepath1, filepath2):
+            """
+            Asserts that two .vcf files contain the same variant findings.
+
+            - Ignores potentially date-stamped comments (lines starting with '#').
+            - Ignores quality scores in .vcf files and only checks that they found
+              the same variants.  This is due to assumed small observed rounding
+              differences between systems.
+
+            VCF File Column Contents:
+            1: #CHROM
+            2: POS
+            3: ID
+            4: REF
+            5: ALT
+            6: QUAL
+            7: FILTER
+            8: INFO
+
+            :param filepath1: First .vcf file to compare.
+            :param filepath2: Second .vcf file to compare.
+            """
+            with open(filepath1) as default_file:
                 good_data = []
                 for line in default_file:
+                    line = line.strip()
                     if not line.startswith('#'):
-                        good_data.append(line)
-                for test_file in test_output_files:
-                    if file == test_file:
-                        test_filepath = os.path.join(output_dir, file)
-                        if file.endswith(".vcf"):
-                            compare_vcf_files(filepath1=filepath,
-                                              filepath2=test_filepath)
-                        else:
-                            with open(test_filepath) as test_file:
-                                test_data = []
-                                for line in test_file:
-                                    if not line.startswith('#'):
-                                        test_data.append(line)
-                            assert good_data == test_data, "File does not match: %r" % file
+                        good_data.append(line.split('\t'))
 
+            with open(filepath2) as test_file:
+                test_data = []
+                for line in test_file:
+                    line = line.strip()
+                    if not line.startswith('#'):
+                        test_data.append(line.split('\t'))
 
-def compare_vcf_files(filepath1, filepath2):
-    """
-    Asserts that two .vcf files contain the same variant findings.
+            for i in range(len(test_data)):
+                if test_data[i] != good_data[i]:
+                    for j in range(len(test_data[i])):
+                        # Only compare chromosome, position, ID, reference, and alts.
+                        # Quality score may vary (<1%) between systems because of
+                        # (assumed) rounding differences.  Same for the "info" sect.
+                        if j < 5:
+                            if j == 4:
+                                if test_data[i][j].startswith('*,'):
+                                    test_data[i][j] = test_data[i][j][2:]
+                                if good_data[i][j].startswith('*,'):
+                                    good_data[i][j] = good_data[i][j][2:]
+                            assert test_data[i][j] == good_data[i][j], f"\nInconsistent VCFs: {filepath1} != {filepath2}\n" \
+                                                                       f" - {test_data[i][j]} != {good_data[i][j]}\n" \
+                                                                       f" - Line: {i} Column: {j}"
 
-    - Ignores potentially date-stamped comments (lines starting with '#').
-    - Ignores quality scores in .vcf files and only checks that they found
-      the same variants.  This is due to assumed small observed rounding
-      differences between systems.
-
-    VCF File Column Contents:
-    1: #CHROM
-    2: POS
-    3: ID
-    4: REF
-    5: ALT
-    6: QUAL
-    7: FILTER
-    8: INFO
-
-    :param filepath1: First .vcf file to compare.
-    :param filepath2: Second .vcf file to compare.
-    """
-    with open(filepath1) as default_file:
-        good_data = []
-        for line in default_file:
-            line = line.strip()
-            if not line.startswith('#'):
-                good_data.append(line.split('\t'))
-
-    with open(filepath2) as test_file:
-        test_data = []
-        for line in test_file:
-            line = line.strip()
-            if not line.startswith('#'):
-                test_data.append(line.split('\t'))
-
-    for i in range(len(test_data)):
-        if test_data[i] != good_data[i]:
-            for j in range(len(test_data[i])):
-                # Only compare chromosome, position, ID, reference, and alts.
-                # Quality score may vary (<1%) between systems because of
-                # (assumed) rounding differences.  Same for the "info" sect.
-                if j < 5:
-                    if j == 4:
-                        if test_data[i][j].startswith('*,'):
-                            test_data[i][j] = test_data[i][j][2:]
-                        if good_data[i][j].startswith('*,'):
-                            good_data[i][j] = good_data[i][j][2:]
-                    assert test_data[i][j] == good_data[i][j], f"\nInconsistent VCFs: {filepath1} != {filepath2}\n" \
-                                                               f" - {test_data[i][j]} != {good_data[i][j]}\n" \
-                                                               f" - Line: {i} Column: {j}"
-
-try:
-    compare_runs(os.path.join(os.getcwd(), "output"), os.path.join(os.getcwd(), "ref"))
-    print("success")
-except AssertionError as e:
-    print("fail", e)
-CODE
+        try:
+            compare_runs(os.path.join(os.getcwd(), "output"), os.path.join(os.getcwd(), "ref"))
+            print("success")
+        except AssertionError as e:
+            print("fail", e)
+    CODE
     >>>
 
     output {


### PR DESCRIPTION
The latest toil branch is no longer compatible with the integration tests. I think this is because it now applies a fixed deindent to code blocks.

Ex:
```wdl
        python <<CODE
        python code here
        CODE
```
becomes
```wdl
python <<CODE
python code here
CODE
```

But since it forces the deindent, if the code block is already deindented/not indented enough:
```wdl
        python <<CODE
python code here
CODE
```
This will cause an indentation error when parsing the python.

For example, this:
```wdl
        python <<CODE
def func():
    for loop:
        print hello
```
will become:
```wdl
        python <<CODE
def func():
    for loop:
print hello
```
I'm not sure if this is part of the WDL spec, but both MiniWDL and Cromwell can deal with the case when the indentation level is less than the level at the code block declaration.

This also updates some of the images to be compatible with singularity v4 and higher.