### PR TITLE
Update README to reflect new argument + argcomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,16 @@ Testing runner toil-wdl-runner on WDL versions: 1.1
 
 ```
 (venv) quokka@qcore ~/$ python3 run.py --help
-usage: run.py [-h] [--verbose] [--versions VERSIONS] [--tags TAGS] [--numbers NUMBERS] [--runner {cromwell,toil-wdl-runner,miniwdl}] [--threads THREADS] [--time] [--quiet] [--exclude-numbers EXCLUDE_NUMBERS]
-              [--toil-args TOIL_ARGS] [--miniwdl-args MINIWDL_ARGS] [--cromwell-args CROMWELL_ARGS] [--cromwell-pre-args CROMWELL_PRE_ARGS] [--id ID] [--repeat REPEAT] [--jobstore-path JOBSTORE_PATH] [--progress]
+usage: run.py [-h] [--verbose] [--versions {draft-2,1.0,1.1}] [--tags TAGS] [--numbers NUMBERS] [--runner {cromwell,toil-wdl-runner,miniwdl}] [--threads THREADS] [--time] [--quiet]
+              [--exclude-numbers EXCLUDE_NUMBERS] [--toil-args TOIL_ARGS] [--miniwdl-args MINIWDL_ARGS] [--cromwell-args CROMWELL_ARGS] [--cromwell-pre-args CROMWELL_PRE_ARGS] [--id ID]
+              [--repeat REPEAT] [--jobstore-path JOBSTORE_PATH] [--progress]
 
 Run WDL conformance tests.
 
 options:
   -h, --help            show this help message and exit
   --verbose             Print more information about a test
-  --versions VERSIONS, -v VERSIONS
+  --versions {draft-2,1.0,1.1}, -v {draft-2,1.0,1.1}
                         Select the WDL versions you wish to test against. Ex: -v=draft-2,1.0
   --tags TAGS, -t TAGS  Select the tags to run specific tests
   --numbers NUMBERS, -n NUMBERS
@@ -77,13 +78,13 @@ options:
   --cromwell-args CROMWELL_ARGS
                         Arguments to pass into cromwell. Ex: --cromwell-args="--options=[OPTIONS]"
   --cromwell-pre-args CROMWELL_PRE_ARGS
-                        Arguments to set java system properties before calling cromwell. This allows things such as setting cromwell config files with --cromwell-pre-args="-Dconfig.file=build/overrides.conf".
+                        Arguments to set java system properties before calling cromwell. This allows things such as setting cromwell config files with --cromwell-pre-
+                        args="-Dconfig.file=build/overrides.conf".
   --id ID               Specify WDL tests by ID.
   --repeat REPEAT       Specify how many times to run each test.
   --jobstore-path JOBSTORE_PATH, -j JOBSTORE_PATH
                         Specify the PARENT directory for the jobstores to be created in.
   --progress            Print the progress of the test suite as it runs.
-
 ```
 Invoking `run.py` with no options will result in the entire test suite being run, which can take a long time.
 Including `--progress` is recommended when running over a long period of time.

--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ Testing runner toil-wdl-runner on WDL versions: 1.1
 
 ```
 (venv) quokka@qcore ~/$ python3 run.py --help
-usage: run.py [-h] [--verbose] [--versions VERSIONS] [--tags TAGS]
-              [--numbers NUMBERS] [--runner RUNNER] [--threads THREADS]
+usage: run.py [-h] [--verbose] [--versions VERSIONS] [--tags TAGS] [--numbers NUMBERS] [--runner {cromwell,toil-wdl-runner,miniwdl}] [--threads THREADS] [--time] [--quiet] [--exclude-numbers EXCLUDE_NUMBERS]
+              [--toil-args TOIL_ARGS] [--miniwdl-args MINIWDL_ARGS] [--cromwell-args CROMWELL_ARGS] [--cromwell-pre-args CROMWELL_PRE_ARGS] [--id ID] [--repeat REPEAT] [--jobstore-path JOBSTORE_PATH] [--progress]
 
 Run WDL conformance tests.
 
 options:
   -h, --help            show this help message and exit
   --verbose             Print more information about a test
-  --versions {1.0,1.1,draft-2}, -v {1.0,1.1,draft-2}
-                        Select the WDL versions you wish to test against.
+  --versions VERSIONS, -v VERSIONS
+                        Select the WDL versions you wish to test against. Ex: -v=draft-2,1.0
   --tags TAGS, -t TAGS  Select the tags to run specific tests
   --numbers NUMBERS, -n NUMBERS
                         Select the WDL test numbers you wish to run. Can be a comma separated list or hyphen separated inclusive ranges. Ex: -n=1-4,6,8-10
-  --runner RUNNER, -r RUNNER
+  --runner {cromwell,toil-wdl-runner,miniwdl}, -r {cromwell,toil-wdl-runner,miniwdl}
                         Select the WDL runner to use.
   --threads THREADS     Number of tests to run in parallel. The maximum should be the number of CPU cores (not threads due to wall clock timing).
   --time                Time the conformance test run.
@@ -76,6 +76,8 @@ options:
                         Arguments to pass into miniwdl. Ex: --miniwdl-args="--no-outside-imports"
   --cromwell-args CROMWELL_ARGS
                         Arguments to pass into cromwell. Ex: --cromwell-args="--options=[OPTIONS]"
+  --cromwell-pre-args CROMWELL_PRE_ARGS
+                        Arguments to set java system properties before calling cromwell. This allows things such as setting cromwell config files with --cromwell-pre-args="-Dconfig.file=build/overrides.conf".
   --id ID               Specify WDL tests by ID.
   --repeat REPEAT       Specify how many times to run each test.
   --jobstore-path JOBSTORE_PATH, -j JOBSTORE_PATH

--- a/lib.py
+++ b/lib.py
@@ -6,7 +6,7 @@ import subprocess
 from WDL.Type import Float as WDLFloat, String as WDLString, File as WDLFile, Int as WDLInt, Boolean as WDLBool, \
     Array as WDLArray, Map as WDLMap, Pair as WDLPair, StructInstance as WDLStruct
 
-from typing import Optional, Iterable, Any, Dict, Tuple, List
+from typing import Optional, Any
 from WDL.Type import Base as WDLBase
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ miniwdl>=1.11.0,<2
 pandas>=2.1.4,<3
 numpy>=1.26.2,<2
 matplotlib>=3.8.2,<4
+argcomplete

--- a/run.py
+++ b/run.py
@@ -12,20 +12,19 @@ import sys
 import hashlib
 import argparse
 import argcomplete
-import subprocess
 import threading
 import timeit
 
 from ruamel.yaml import YAML
 
-from concurrent.futures import ThreadPoolExecutor, as_completed, ProcessPoolExecutor
+from concurrent.futures import as_completed, ProcessPoolExecutor
 from shutil import which
 from uuid import uuid4
 
 from WDL.Type import Float as WDLFloat, String as WDLString, File as WDLFile, Int as WDLInt, Boolean as WDLBool, \
     Array as WDLArray, Map as WDLMap, Pair as WDLPair, StructInstance as WDLStruct
 
-from typing import Optional, Iterable, Any, Dict, Tuple, List
+from typing import Optional, Any, Dict, Tuple, List
 from WDL.Type import Base as WDLBase
 
 from lib import run_cmd, py_type_of_wdl_class, verify_failure, announce_test, print_response, convert_type, run_setup, \

--- a/run.py
+++ b/run.py
@@ -30,6 +30,10 @@ from WDL.Type import Base as WDLBase
 from lib import run_cmd, py_type_of_wdl_class, verify_failure, announce_test, print_response, convert_type, run_setup, \
     get_specific_tests, get_wdl_file
 
+
+WDL_VERSIONS = ["draft-2", "1.0", "1.1"]
+
+
 class WDLRunner:
     """
     A class describing how to invoke a WDL runner to run a workflow.
@@ -285,11 +289,7 @@ class WDLConformanceTestRunner:
         wdl_input = inputs.get('wdl', f'{wdl_dir}.wdl')  # default wdl name
         json_input = inputs.get('json', f'{wdl_dir}.json')  # default json name
         abs_wdl_dir = os.path.abspath(wdl_dir)
-        if version == "draft-2":
-            wdl_input = f'{wdl_dir}/{wdl_input}'
-        elif version == "1.0":
-            wdl_input = f'{wdl_dir}/{wdl_input}'
-        elif version == "1.1":
+        if version in WDL_VERSIONS
             wdl_input = f'{wdl_dir}/{wdl_input}'
         else:
             return {'status': 'FAILED', 'reason': f'WDL version {version} is not supported!'}
@@ -468,7 +468,7 @@ def add_options(parser) -> None:
     """
     parser.add_argument("--verbose", default=False, action='store_true',
                         help='Print more information about a test')
-    parser.add_argument("--versions", "-v", default="1.0",
+    parser.add_argument("--versions", "-v", default="1.0", choices=WDL_VERSIONS,
                         help='Select the WDL versions you wish to test against. Ex: -v=draft-2,1.0')
     parser.add_argument("--tags", "-t", default=None,
                         help='Select the tags to run specific tests')

--- a/run_performance.py
+++ b/run_performance.py
@@ -13,8 +13,6 @@ import timeit
 from typing import Dict, Any, List
 
 import argcomplete
-import regex
-import subprocess
 import sys
 
 from lib import parse_time

--- a/unpatch.py
+++ b/unpatch.py
@@ -1,7 +1,14 @@
+#!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
+"""
+Reverse the effects of patch.py from the generated base WDL file and the existing patchfiles (when the original WDL files were deleted).
+"""
 import argparse
 import os
 import subprocess
 import sys
+
+import argcomplete
 
 from lib import get_wdl_version_from_file
 
@@ -87,6 +94,7 @@ def main(argv=None):
     parser.add_argument("--file", "-f", default=None,
                         help="File name of base WDL file. If specified, it will use it to create patched files from."
                              "Takes priority over --version")
+    argcomplete.autocomplete(parser)
     args = parser.parse_args(argv)
 
     unpatch(args.directory, args.version, args.file)


### PR DESCRIPTION
The `run.py` help section had an outdated `--help` output, so this updates that. Also adds argcomplete to `unpatch.py` and removes some dead imports. Also added argcomplete to the requirements.