### PR TITLE
Indent heredoc end to same level as start

### DIFF
--- a/integration/gatk/tut04/jointCallingGenotypes.wdl
+++ b/integration/gatk/tut04/jointCallingGenotypes.wdl
@@ -220,7 +220,7 @@ task validate_and_gather_the_output {
             print("success")
         except AssertionError as e:
             print("fail", e)
-    CODE
+        CODE
     >>>
 
     output {


### PR DESCRIPTION
Without this, removing the common leading whitespace breaks the heredoc.